### PR TITLE
[FEAT1] : multi-step-from : form validation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -152,7 +152,7 @@ li {
   padding-bottom: 15px;
 }
 
-input:invalid {
+input:invalid:not(:placeholder-shown) {
   border: 1px solid red;
   background-color: #ffeeee;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -123,6 +123,18 @@ section[aria-current="false"] {
   border-width: 0;
 }
 
+span[aria-current="false"] {
+  width: 1px;
+  height: 1px;
+  position: absolute;
+  overflow: hidden;
+  padding: 0;
+  margin: -1px;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 label {
   display: block;
   margin-bottom: 20px;
@@ -141,7 +153,7 @@ li {
 }
 
 input:invalid {
-  border: 2px dashed red;
+  border: 2px solid red;
 }
 
 input:valid {

--- a/app/globals.css
+++ b/app/globals.css
@@ -152,7 +152,7 @@ li {
   padding-bottom: 15px;
 }
 
-input:invalid:not(:placeholder-shown) {
+input:invalid {
   border: 1px solid red;
   background-color: #ffeeee;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -153,9 +153,6 @@ li {
 }
 
 input:invalid {
-  border: 2px solid red;
-}
-
-input:valid {
-  border: 2px solid black;
+  border: 1px solid red;
+  background-color: #ffeeee;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -139,3 +139,11 @@ input {
 li {
   padding-bottom: 15px;
 }
+
+input:invalid {
+  border: 2px dashed red;
+}
+
+input:valid {
+  border: 2px solid black;
+}

--- a/app/multi-step-form/_components/FormContainer.tsx
+++ b/app/multi-step-form/_components/FormContainer.tsx
@@ -18,6 +18,19 @@ export const FormContainer = ({
 }) => {
   const id = useId();
 
+  const isRequiredFilled = (): boolean => {
+    let valid: boolean = true;
+    const inputs: NodeListOf<HTMLInputElement> =
+      document.querySelectorAll<HTMLInputElement>("input[required]"); // 이렇게 해서 못찾는것같음.... ㅠ
+    for (const input of inputs) {
+      if (input.value.trim() === "") {
+        valid = false;
+        break;
+      }
+    }
+    return valid;
+  };
+
   return (
     <section
       className={styles.stepSection}
@@ -25,7 +38,11 @@ export const FormContainer = ({
       aria-describedby={id + "-description"}
       aria-current={isFocused ? "step" : "false"}
     >
-      <form onSubmit={(event) => handleOnSubmit(event)}>
+      <form
+        onSubmit={(event) => {
+          if (isRequiredFilled()) handleOnSubmit(event);
+        }}
+      >
         <h3 id={id + "-title"} className={styles.headerText}>
           {title}
         </h3>

--- a/app/multi-step-form/_components/FormStepOne.tsx
+++ b/app/multi-step-form/_components/FormStepOne.tsx
@@ -14,12 +14,7 @@ export const FormStepOne = () => {
         </label>
         <label>
           이메일 주소
-          <input
-            name="email"
-            placeholder="예) test@test.com"
-            pattern="[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
-            required
-          />
+          <input name="email" type="email" placeholder="예) test@test.com" />
         </label>
         <label>
           전화번호

--- a/app/multi-step-form/_components/FormStepOne.tsx
+++ b/app/multi-step-form/_components/FormStepOne.tsx
@@ -1,7 +1,10 @@
-import { FormEvent } from "react";
+"use client";
+
+import { FormEvent, useState } from "react";
 import styles from "./formContainer.module.css";
 
 export const FormStepOne = () => {
+  const [showErrorMessage, setShowErrorMessage] = useState(false);
   return (
     <>
       <div className={styles.mainContent}>
@@ -15,7 +18,18 @@ export const FormStepOne = () => {
         </label>
         <label>
           전화번호
-          <input name="phoneNumber" placeholder="예) 010-1234-5678" />
+          <input
+            name="phoneNumber"
+            placeholder="예) 010-1234-5678"
+            required
+            onInvalid={() => setShowErrorMessage(true)}
+          />
+          <span
+            aria-current={showErrorMessage ? "true" : "false"}
+            className={styles.errorMessage}
+          >
+            * 전화번호는 필수입력 구간입니다.
+          </span>
         </label>
       </div>
       <button type="submit" className={styles.submitButton}>

--- a/app/multi-step-form/_components/FormStepOne.tsx
+++ b/app/multi-step-form/_components/FormStepOne.tsx
@@ -22,6 +22,7 @@ export const FormStepOne = () => {
             name="phoneNumber"
             placeholder="예) 010-1234-5678"
             required
+            pattern="[0-9]{3}-[0-9]{4}-[0-9]{4}"
             onInvalid={() => setShowErrorMessage(true)}
           />
           <span

--- a/app/multi-step-form/_components/FormStepOne.tsx
+++ b/app/multi-step-form/_components/FormStepOne.tsx
@@ -14,7 +14,12 @@ export const FormStepOne = () => {
         </label>
         <label>
           이메일 주소
-          <input name="email" placeholder="예) test@test.com" />
+          <input
+            name="email"
+            placeholder="예) test@test.com"
+            pattern="[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
+            required
+          />
         </label>
         <label>
           전화번호

--- a/app/multi-step-form/_components/MultiStepFormView.tsx
+++ b/app/multi-step-form/_components/MultiStepFormView.tsx
@@ -82,6 +82,7 @@ export const MultiStepFormView = () => {
 
   const handleOnSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
     const formData = new FormData(event.currentTarget);
     if (step === 2) {
       handleToggleInput(formData);

--- a/app/multi-step-form/_components/formContainer.module.css
+++ b/app/multi-step-form/_components/formContainer.module.css
@@ -221,3 +221,10 @@ label:has(input:checked) .slider:before {
   border: solid 3px #d19cf0;
   background: #e3ccf0;
 }
+
+.errorMessage {
+  color: red;
+  font-size: 13px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}


### PR DESCRIPTION
## 한것
- 이메일 주소 인풋에 이메일 형식 validation을 붙였습니다
  - 제가 따로 구현하진 않았고, `input type="email"`을 사용하였습니다.
- 전화번호 인풋에 `pattern` 속성을 통해 형식 validation 로직을 추가했습니다.
- 전화번호 인풋에 `required` 속성을 추가하고, 인풋값이 빈 상태로 제출하면 하단 커스텀 에러 메시지가 나오게 설정해주었습니다.
- required field 를 모두 입력하지 않은 상태라면, 다음 페이지로 넘어갈 수 없게 onSubmit 함수 쪽에 isRequiredFilled 를 먼저 확인하도록 로직을 추가해주었습니다. 

## 시도했으나 실패한것
- `required` 속성을 추가한 인풋의 경우 (ex. 전화번호 인풋), 저는 첫 제출 전에는 해당 인풋이 비어있는 상태여도 빨간 border 등 `:invalid` 일때만 적용되는 스타일이 적용되지 않았으면 좋겠는데, 계속 initial style이 이미 invalid인 상태로 적용이 됩니다. 
  - 문제해결을 위해 gpt의 도움을 받아 "initial styling for :invalid input" 등으로 검색해보았습니다.
  - 검색결과, css에서 사용할 수 있는 placeholder-shown 이라는 녀석이 있는것 같아 `input:not(:placeholder-shown):invalid` 로 시도해봤는데, invalid 스타일이 아예 안먹더라구요 ㅠ

## 참고용 스샷
<img width="1057" alt="image" src="https://github.com/JunnieLee/web-standards-considered-components/assets/33515577/4d4e515b-f70a-4202-b23a-c53fd517fdc3">
