### PR TITLE
[FEAT1] : multi-step-from : step2 toggle쪽 radio로 변경 + accessible-hidden 글로벌 css 클래스로 빼기

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -111,30 +111,6 @@ a[aria-current="page"] {
   color: purple;
 }
 
-section[aria-current="false"] {
-  width: 1px;
-  height: 1px;
-  position: absolute;
-  overflow: hidden;
-  padding: 0;
-  margin: -1px;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-
-span[aria-current="false"] {
-  width: 1px;
-  height: 1px;
-  position: absolute;
-  overflow: hidden;
-  padding: 0;
-  margin: -1px;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-
 label {
   display: block;
   margin-bottom: 20px;
@@ -155,4 +131,18 @@ li {
 input:invalid {
   border: 1px solid red;
   background-color: #ffeeee;
+}
+
+section[aria-current="false"],
+span[aria-current="false"],
+.accessible-hidden {
+  width: 1px;
+  height: 1px;
+  position: absolute;
+  overflow: hidden;
+  padding: 0;
+  margin: -1px;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -146,3 +146,13 @@ span[aria-current="false"],
   white-space: nowrap;
   border-width: 0;
 }
+
+button {
+  background: inherit;
+  border: none;
+  box-shadow: none;
+  border-radius: 0;
+  padding: 0;
+  overflow: visible;
+  cursor: pointer;
+}

--- a/app/multi-step-form/_components/FormStepTwo.tsx
+++ b/app/multi-step-form/_components/FormStepTwo.tsx
@@ -10,6 +10,22 @@ export const FormStepTwo = ({
 }: {
   onClickGoBackButton: () => void;
 }) => {
+  const handleToggle = () => {
+    // (1) toggle 관련 radio input들 가지고 오기
+    const monthlyPaymentRadio = document.getElementById(
+      "payment-interval-monthly"
+    ) as HTMLInputElement;
+    const yearlyPaymentRadio = document.getElementById(
+      "payment-interval-yearly"
+    ) as HTMLInputElement;
+    // (2) check 상태 바꾸어주기 (토글처리)
+    if (monthlyPaymentRadio.checked) {
+      yearlyPaymentRadio.checked = true;
+    } else {
+      monthlyPaymentRadio.checked = true;
+    }
+  };
+
   return (
     <>
       <div
@@ -71,6 +87,7 @@ export const FormStepTwo = ({
         <label className={styles.paymentIntervalLabel}>
           Monthly
           <input
+            id="payment-interval-monthly"
             type="radio"
             name="payment-interval"
             value="monthly"
@@ -78,12 +95,13 @@ export const FormStepTwo = ({
             className={"accessible-hidden"}
           />
         </label>
-        <span className={styles.toggle}>
+        <button className={styles.toggle} type="button" onClick={handleToggle}>
           <span className={styles.slider}></span>
-        </span>
+        </button>
         <label className={styles.paymentIntervalLabel}>
           Yearly
           <input
+            id="payment-interval-yearly"
             type="radio"
             name="payment-interval"
             value="yearly"

--- a/app/multi-step-form/_components/FormStepTwo.tsx
+++ b/app/multi-step-form/_components/FormStepTwo.tsx
@@ -27,7 +27,7 @@ export const FormStepTwo = ({
             name="plan"
             value="basic"
             defaultChecked
-            className={styles.hidden}
+            className={"accessible-hidden"}
           />
           <Image
             src={IconArcade}
@@ -42,7 +42,7 @@ export const FormStepTwo = ({
             type="radio"
             name="plan"
             value="plus"
-            className={styles.hidden}
+            className={"accessible-hidden"}
           />
           <Image
             src={IconAdvanced}
@@ -57,7 +57,7 @@ export const FormStepTwo = ({
             type="radio"
             name="plan"
             value="pro"
-            className={styles.hidden}
+            className={"accessible-hidden"}
           />
           <Image
             src={IconPro}
@@ -73,7 +73,7 @@ export const FormStepTwo = ({
           type="checkbox"
           name="payment-interval-monthly"
           defaultChecked
-          className={styles.hidden}
+          className={"accessible-hidden"}
         />
         <span className={styles.toggle}>
           <span className={styles.slider}></span>

--- a/app/multi-step-form/_components/FormStepTwo.tsx
+++ b/app/multi-step-form/_components/FormStepTwo.tsx
@@ -67,19 +67,31 @@ export const FormStepTwo = ({
           <p>25,000원/(월)</p>
         </label>
       </div>
-      <label className={styles.planToggleSection}>
-        <span className={styles.pros}>Monthly</span>
-        <input
-          type="checkbox"
-          name="payment-interval-monthly"
-          defaultChecked
-          className={"accessible-hidden"}
-        />
+      <div className={styles.planToggleSection}>
+        <label className={styles.paymentIntervalLabel}>
+          Monthly
+          <input
+            type="radio"
+            name="payment-interval"
+            value="monthly"
+            defaultChecked
+            className={"accessible-hidden"}
+          />
+        </label>
         <span className={styles.toggle}>
           <span className={styles.slider}></span>
         </span>
-        <span className={styles.cons}>Yearly</span>
-      </label>
+        <label className={styles.paymentIntervalLabel}>
+          Yearly
+          <input
+            type="radio"
+            name="payment-interval"
+            value="yearly"
+            className={"accessible-hidden"}
+          />
+        </label>
+      </div>
+
       <button
         type="button"
         onClick={onClickGoBackButton}

--- a/app/multi-step-form/_components/MultiStepFormView.tsx
+++ b/app/multi-step-form/_components/MultiStepFormView.tsx
@@ -71,22 +71,11 @@ export const MultiStepFormView = () => {
     return obj;
   };
 
-  const handleToggleInput = (formData: FormData) => {
-    const isPaymentIntervalMonthly = formData.has("payment-interval-monthly"); // true, false
-    formData.delete("payment-interval-monthly");
-    formData.set(
-      "payment-interval",
-      isPaymentIntervalMonthly ? "monthly" : "yearly"
-    );
-  };
-
   const handleOnSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     const formData = new FormData(event.currentTarget);
-    if (step === 2) {
-      handleToggleInput(formData);
-    }
+
     setFormState((old) => ({
       ...old,
       ...formDataToObject(formData),

--- a/app/multi-step-form/_components/formContainer.module.css
+++ b/app/multi-step-form/_components/formContainer.module.css
@@ -100,24 +100,14 @@
   align-items: center;
 }
 
-.pros {
+.paymentIntervalLabel {
   width: 70px;
-  margin-right: 10px;
+  margin: 10px;
   font-weight: 400;
 }
 
-label:has(input:checked) .pros {
+.paymentIntervalLabel:has(input:checked) {
   font-weight: 600;
-}
-
-.cons {
-  width: 70px;
-  font-weight: 600;
-  margin-left: 10px;
-}
-
-label:has(input:checked) .cons {
-  font-weight: 400;
 }
 
 .toggle {
@@ -151,7 +141,7 @@ label:has(input:checked) .cons {
   border-radius: 50%;
 }
 
-label:has(input:checked) .slider:before {
+div:has(input[value="monthly"]:checked) .slider:before {
   transform: translateX(-26px);
 }
 

--- a/app/multi-step-form/_components/formContainer.module.css
+++ b/app/multi-step-form/_components/formContainer.module.css
@@ -82,18 +82,6 @@
   flex-direction: column;
 }
 
-.hidden {
-  width: 1px;
-  height: 1px;
-  position: absolute;
-  overflow: hidden;
-  padding: 0;
-  margin: -1px;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-
 .planIcon {
   width: 70px;
   margin-top: 15px;


### PR DESCRIPTION
# 개요
- 지난번 첫 PR 리뷰때 말씀주셨지만, 미처 고치지 못했던 부분을 오늘 작업했습니다~!

# 작업한 부분

### 1. accessible-hidden 글로벌 css 클래스로 빼기
- before : 
  - (1) tailwind-css의 sr-only와 동일한 스타일의 클래스 네임이 hidden 이었습니다. display:hidden과 혼동될 여지가 있고, 여러모로 이름이 명확치 않다는 문제가 있었습니다.
  - (2) 해당 클래스가 로컬 css module에 존재하였습니다. 범용적으로 쓰일 수 있는 스타일이므로, 글로벌 스코프로 분리할 필요가 있었습니다.
- after :
  - (1) tailwind-css의 sr-only 라는 이름도 사실 이름만 들어서는 곧바로 무엇을 의미하는지 이해하기 힘들다고 판단했습니다. gpt에게 상황을 설명하고, 적절한 클래스 네임을 몇가지 추천해달라고 하였고, 그중 'accessible-hidden'이 가장 좋아 이것으로 새로운 이름을 결정했습니다.
  - (2) global.css로 해당 클래스 위치를 옮겼습니다.

### 2. step2 하단의 payment interval toggle 부분을 radio input으로 변경하였습니다.
- 기존엔 checkbox input으로 되어있어 기계가 읽고 이해하기 어려운 형태로 구성되어있고, form data 처리도 특수하게 따로 해줘야한다는 문제가 있었습니다.
- 이에, checkbox input 대신 radio input으로 인풋 타입을 변경하였습니다. (기존에 해당부분의 form data 를 따로 처리하도록 만들어줬던 함수도 삭제하였습니다)
- 또한, 두 radio input 사이에 toggle button 하나를 두어, 버튼 클릭시 실제 로직상의 토글 처리를 해주도록 구현하였습니다.
  - 근데 이 방식이 선언적 UI를 표방하는 리액트와는 반대로, 명령형 방식으로 작성되어서 마음이 불-편 합니다 🤕 어떻게 다른식으로 할 수 있을지...흠 🤨  

# 미니 회고
- 요즘 한번 작업할때 최대 2시간이 넘어가지 않도록 목표하고 작업하고 있습니다!
  - 이번 작업은 1시간 반 동안 진행하였습니다!
  - 삽질이 나름 최소화 되었습니다!
    - 바꾼 부분 : gpt 좀더 잘 활용하기, 검색할때 최대한 공신력 있는 문서들 위주로 확인하기, 최대한 빠르게 원하는 것을 구현할 수 있는 방향으로 진행하기
- 조언주셨던 대로 좀더 재미에 집중해 작업해보고 있습니다 😄 
- 다음은 무얼 해볼까 생각중입니다!
